### PR TITLE
Make Executor log events

### DIFF
--- a/examples/job.json
+++ b/examples/job.json
@@ -1,0 +1,62 @@
+{
+	"task": {
+		"name": "processCcd",
+		"args": [ "--id", "visit=904010", "ccd=4" ]
+	},
+	"input": {
+		"root": "/tmp/input",
+		"mapper": "lsst.obs.hsc.HscMapper"
+	},
+	"output": {
+		"root": "/tmp/output"
+	},
+	"calibs": [
+		{
+			"pfn": "BIAS-2013-11-03-004.fits",
+			"meta": {
+				"type": "bias",
+				"validity": 999,
+				"calibDate": "2013-11-03",
+				"ccd": 4,
+				"template": "CALIB/BIAS/{calibDate:s}/NONE/BIAS-{calibDate:s}-{ccd:03d}.fits"
+			}
+		},
+		{
+			"pfn": "DARK-2013-11-03-004.fits",
+			"meta": {
+				"type": "dark",
+				"validity": 999,
+				"calibDate": "2013-11-03",
+				"ccd": 4,
+				"template": "CALIB/DARK/{calibDate:s}/NONE/DARK-{calibDate:s}-{ccd:03d}.fits"
+			}
+		},
+		{
+			"pfn": "FLAT-2013-11-03-HSC-I-004.fits",
+			"meta": {
+				"type": "flat",
+				"validity": 999,
+				"calibDate": "2013-11-03",
+				"filter": "HSC-I",
+				"ccd": 4,
+				"template": "CALIB/FLAT/{calibDate:s}/{filter:s}/FLAT-{calibDate:s}-{filter:s}-{ccd:03d}.fits"
+			}
+		},
+		{
+			"pfn": "brighter_fatter_kernel.pkl",
+			"meta": {
+				"type": "bfKernel",
+				"validity": null,
+				"template": "CALIB/BFKERNEL/brighter_fatter_kernel.pkl"
+			}
+		}
+	],
+	"data": [
+		{
+			"pfn": "HSCA90401142.fits",
+			"meta": {
+				"type": "raw"
+			}
+		}
+	]
+}

--- a/examples/logging.json
+++ b/examples/logging.json
@@ -1,0 +1,19 @@
+{
+	"version": 1,
+	"formatters": {
+		"simple": {
+			"format": "%(levelname)s:%(name)s:%(message)s"
+		}
+	},
+	"handlers": {
+		"default": {
+			"class": "logging.FileHandler",
+			"filename": "executor.log",
+			"formatter": "simple"
+		}
+	},
+	"root": {
+		"handlers": ["default"],
+		"level": "INFO"
+	}
+}

--- a/executor/invoker.py
+++ b/executor/invoker.py
@@ -1,9 +1,31 @@
 import argparse
 import json
 import jsonschema
+import logging
+import logging.config
+import os
 from .mapper import TaskMapper
 from .commands import InitRepo, IngestCalibs, IngestData, RunTask
 from .schema import default
+
+
+def setup_logging(path='logging.json', level=logging.INFO):
+    """Setup logging configuration.
+    
+    Parameters
+    ----------
+    path : `str`
+        Path to logging configuration in JSON format.
+    level : `int`
+        Log level.
+    """
+    if os.path.exists(path):
+        with open(path, 'r') as f:
+            config = json.load(f)
+        logging.config.dictConfig(config)
+    else:
+        logging.basicConfig(level=level)
+    return logging.getLogger(__name__)
 
 
 def create_parser():
@@ -17,6 +39,10 @@ def create_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('file', type=str,
                         help='job specification')
+    parser.add_argument('-d', '--dry-run', dest='dryrun', action='store_false',
+                        help='print commands instead execute')
+    parser.add_argument('-l', '--logging',
+                        help='logging configuration')
     parser.add_argument('-s', '--schema', type=str,
                         help='JSON schema', default=None)
     return parser
@@ -33,24 +59,35 @@ def execute(argv):
     parser = create_parser()
     args = parser.parse_args(argv[1:])
 
+    logger = setup_logging(level=logging.INFO)
+    if args.logging is not None:
+        logger = setup_logging(path=args.logging)
+    logger.info('Logger configured, starting logging events.')
+
+    logger.info('Reading job description from \'%s\'.' % args.file)
     with open(args.file, 'r') as f:
         job = json.load(f)
+
+    msg = 'Validating job description; '
     if args.schema is not None:
         with open(args.schema, 'r') as s:
             schema = json.load(s)
+        msg += 'using schema from \'%s\'.'.format(args.schema)
     else:
         schema = default
+        msg += 'using internal schema.'
+    logger.info(msg)
     jsonschema.validate(job, schema)
 
     root = job['input']['root']
 
-    # Create a map between task names and the code (i.e. modules and classes).
+    # Build a map between task names and their code, i.e. modules and classes.
     snowflakes = {
         'ingestImages': ('lsst.pipe.tasks.ingest', 'IngestTask'),
     }
     mapper = TaskMapper(['lsst.pipe.tasks'], special=snowflakes)
 
-    # Start building the command queue.
+    logger.info('Building command queue...')
     queue = []
 
     # If the value of the field 'data' contains list of file specifications,
@@ -58,16 +95,20 @@ def execute(argv):
     data = job.get('data')
     if data is not None:
         if not data:
-            raise ValueError('no files to ingest.')
+            msg = 'No files to ingest'
+            logger.error(msg)
+            raise ValueError(msg)
 
         # Add the command that will create an empty butler repository at a
         # given location with a required mapper.
         try:
             mapping = job['input']['mapper']
         except KeyError:
-            raise ValueError('mapper not specified, '
-                             'cannot create butler repository.')
-        queue.append(InitRepo(root, mapping))
+            msg = 'Mapper not specified, cannot create dataset repository.'
+            logger.error(msg)
+            raise ValueError(msg)
+        cmd = InitRepo(root, mapping)
+        queue.append(cmd)
 
         # Add the command which will ingest raw data.
         name = 'ingestImages'
@@ -75,7 +116,8 @@ def execute(argv):
         task = mapper.get_task(name)
         files = [rec['pfn'] for rec in data]
         opts = tmpl.format(mod='copy').split()
-        queue.append(IngestData(task, root, files, opts))
+        cmd = IngestData(task, root, files, opts)
+        queue.append(cmd)
 
         # Add the commands which will ingest calibration data, if any.
         calibs = job.get('calibs')
@@ -97,7 +139,8 @@ def execute(argv):
 
                 val = str(meta.get('validity', 999))
                 opts = tmpl.format(path=root, type=kind, val=val).split()
-                queue.append(IngestData(task, root, filename, opts))
+                cmd = IngestData(task, root, opts, filename)
+                queue.append(cmd)
 
             # And this is the place where things are getting really funny.
             # The LSST task responsible for ingesting calibration files to
@@ -105,15 +148,24 @@ def execute(argv):
             # updates the repository's registry.  Placing the files in
             # the expected locations is apparently left as an exercise for
             # a reader.
-            queue.append(IngestCalibs(root, calibs))
+            cmd = IngestCalibs(root, calibs)
+            queue.append(cmd)
 
     # Add the command which will run the LSST task.
-    name, args = job['task']['name'], job['task']['args']
+    name, argv = job['task']['name'], job['task']['args']
     tmpl = '--output {out} {args}'
-    args = tmpl.format(out=job['output']['root'], args=' '.join(args)).split()
+    argv = tmpl.format(out=job['output']['root'], args=' '.join(argv)).split()
     task = mapper.get_task(name)
-    queue.append(RunTask(task, root, args))
+    cmd = RunTask(task, root, argv)
+    queue.append(cmd)
 
     # Finally, execute the enqueued commands.
-    for cmd in queue:
-        cmd.execute()
+    logger.info('Finished building, starting to execute commands...')
+    if args.dryrun is True:
+        for cmd in queue:
+            logger.info('Executing: {}'.format(cmd))
+            cmd.execute()
+    else:
+        for cmd in queue:
+            logger.debug('Executing: {!r}'.format(cmd))
+    logger.info('Done.')


### PR DESCRIPTION
Executor was not logging any events.  It made debugging or following
execution of its command queue impossible without changing its code.  To
address this shortcoming I used standard Python logging module to record
the events events during its execution.

Be default, events with severity level INFO or higher are logged to
standard output.  However, the logger can be extensively customised to
one's needs via an external file (see PEP 391).  An example of such
configuration file may be found in "example/logging.json".